### PR TITLE
Fix route

### DIFF
--- a/Resources/config/navigation.yml
+++ b/Resources/config/navigation.yml
@@ -19,4 +19,4 @@ oro_menu_config:
             eltrino_amazon_orders: ~
 
 oro_titles:
-  eltrino_amazon_orders: 'Amazon Orders'
+  eltrino_amazon_order_index: 'Amazon Orders'


### PR DESCRIPTION
Load "Title Templates" from annotations and config files to db                 
                                          
  [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]
  Title for route "eltrino_amazon_orders" could not be saved. Route not found.